### PR TITLE
Use latest versions to fix security vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.2.1.RELEASE</version>
+        <version>2.5.3</version>
         <relativePath/>
     </parent>
 
@@ -18,8 +18,8 @@
 
     <properties>
         <java.version>11</java.version>
-        <oauth2.version>2.1.1.RELEASE</oauth2.version>
-        <commonsio.version>2.7</commonsio.version>
+        <oauth2.version>2.5.2</oauth2.version>
+        <commonsio.version>2.11.0</commonsio.version>
         <docusign.version>3.13.0-RC1</docusign.version>
         <rooms.version>1.1.0-RC1</rooms.version>
         <click.version>1.0.0-BETA</click.version>

--- a/src/main/java/com/docusign/core/model/DoneExample.java
+++ b/src/main/java/com/docusign/core/model/DoneExample.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
 import com.google.gson.Gson;
-import org.codehaus.jackson.map.SerializationConfig;
+import com.fasterxml.jackson.databind.SerializationConfig;
 import org.json.JSONObject;
 import org.springframework.ui.ModelMap;
 


### PR DESCRIPTION
### Summary of Changes

- Bumped Spring Boot version from `2.2.1.RELEASE` to `2.5.3`
- Bumped Spring OAuth2 dependency from `2.1.1.RELEASE` to `2.5.2`
- Bumped `commons-io` dependency from `2.7` to `2.11.0`
- Replaced `org.codehaus.jackson.map.SerializationConfig` with `com.fasterxml.jackson.databind.SerializationConfig`

### Tests

- Application starts up successfully.
- EG001 to EG013 tested successfully
- EG016 to EG021 tested successfully
- EG024 tested successfully

### Documentation

- No change
